### PR TITLE
Flipped dimensions

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -7,7 +7,7 @@ API Reference
 filtertools
 -----------
 
-.. automodule:: filtertools
+.. automodule:: pyret.filtertools
     :members:
     :undoc-members:
     :show-inheritance:
@@ -15,7 +15,7 @@ filtertools
 nonlinearities
 --------------
 
-.. automodule:: nonlinearities
+.. automodule:: pyret.nonlinearities
     :members:
     :undoc-members:
     :show-inheritance:
@@ -23,7 +23,7 @@ nonlinearities
 spiketools
 ----------
 
-.. automodule:: spiketools
+.. automodule:: pyret.spiketools
     :members:
     :undoc-members:
     :show-inheritance:
@@ -31,7 +31,7 @@ spiketools
 stimulustools
 -------------
 
-.. automodule:: stimulustools
+.. automodule:: pyret.stimulustools
     :members:
     :undoc-members:
     :show-inheritance:
@@ -39,7 +39,7 @@ stimulustools
 visualizations
 --------------
 
-.. automodule:: visualizations
+.. automodule:: pyret.visualizations
     :members:
     :undoc-members:
     :show-inheritance:

--- a/doc/releases/v0.3.rst
+++ b/doc/releases/v0.3.rst
@@ -4,6 +4,10 @@ v0.3 (In Progress)
 
 API changes
 -----------
+- Changed the `filtertools` module's `getste`, `getsta`, and `getstc` to use
+  generators. The `getste` function now returns a generator that yields samples
+  from the spike-triggered ensemble, while `getsta` and `getstc` consume that
+  generator in order to compute their results.
 
 General package changes
 -----------------------

--- a/pyret/__init__.py
+++ b/pyret/__init__.py
@@ -23,6 +23,6 @@ __all__ = [
     'visualizations',
     'filtertools'
     ]
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 
 from pyret import *

--- a/pyret/filtertools.py
+++ b/pyret/filtertools.py
@@ -25,6 +25,26 @@ def getste(time, stimulus, spikes, filter_length):
     """
     Constructs an iterator over spike-triggered stimuli
 
+    Parameters
+    ----------
+    time : ndarray
+        The time array corresponding to the stimulus
+
+    stimulus : ndarray
+        A spatiotemporal or temporal stimulus array
+        (where time is the first dimension)
+
+    spikes : iterable
+        A list or ndarray of spike times
+
+    filter_length : int
+        The desired temporal history / length of the STA
+
+    Returns
+    -------
+    ste : generator
+        A generator that yields samples from the spike-triggered ensemble
+
     """
 
     # Bin spikes
@@ -52,6 +72,7 @@ def getsta(time, stimulus, spikes, filter_length):
 
     stimulus : ndarray
         A spatiotemporal or temporal stimulus array
+        (where time is the first dimension)
 
     spikes : iterable
         A list or ndarray of spike times
@@ -82,6 +103,32 @@ def getsta(time, stimulus, spikes, filter_length):
 
 
 def getstc(time, stimulus, spikes, filter_length):
+    """
+    Compute the spike-triggered covariance
+
+    stc = getstc(time, stimulus, spikes, filter_length)
+
+    Parameters
+    ----------
+    time : ndarray
+        The time array corresponding to the stimulus
+        (where time is the first dimension)
+
+    stimulus : ndarray
+        A spatiotemporal or temporal stimulus array
+
+    spikes : iterable
+        A list or ndarray of spike times
+
+    filter_length : int
+        The desired temporal history / length of the STA
+
+    Returns
+    -------
+    stc : ndarray
+        The spike-triggered covariance (STC) matrix
+
+    """
 
     # initialize
     ndims = np.prod(stimulus.shape[1:]) * filter_length

--- a/pyret/filtertools.py
+++ b/pyret/filtertools.py
@@ -140,7 +140,8 @@ def lowranksta(f_orig, k=10):
 
     # Compute the SVD of the full filter
     try:
-        u, s, v = np.linalg.svd(f.reshape(-1, f.shape[-1]) - np.mean(f),
+        assert f.ndim >= 2, "Filter must be at least 2-D"
+        u, s, v = np.linalg.svd(f.reshape(f.shape[0], -1) - np.mean(f),
                                 full_matrices=False)
     except LinAlgError:
         err = '''The SVD did not converge for the given spatiotemporal filter

--- a/pyret/filtertools.py
+++ b/pyret/filtertools.py
@@ -446,7 +446,7 @@ def filterpeak(sta):
     Parameters
     ----------
     sta : array_like
-        Filter of which to find the peak
+        Filter of which to find the peak (time, space, space)
 
     Returns
     -------

--- a/pyret/filtertools.py
+++ b/pyret/filtertools.py
@@ -15,10 +15,21 @@ from skimage.restoration import denoise_tv_bregman
 from skimage.filters import gaussian_filter
 from scipy.optimize import curve_fit
 from functools import reduce
+from warnings import warn
 
 __all__ = ['getste', 'getsta', 'getstc', 'lowranksta', 'decompose',
            'get_ellipse_params', 'fit_ellipse', 'filterpeak', 'smoothfilter',
            'cutout', 'prinangles', 'rolling_window']
+
+
+def dimension_warning(stim):
+    """
+    Warning for mis-shaped stimuli (due to the time axis flip in pyret v0.3.1)
+    """
+    if np.argmax(stim.shape) != 0:
+        warn('''Your stimulus seems to have the wrong shape.
+             Check to make sure that the time dimension is the first dimension
+             (new in v0.3.1)''', DeprecationWarning, stacklevel=2)
 
 
 def getste(time, stimulus, spikes, filter_length):
@@ -46,6 +57,8 @@ def getste(time, stimulus, spikes, filter_length):
         A generator that yields samples from the spike-triggered ensemble
 
     """
+
+    dimension_warning(stimulus)
 
     # Bin spikes
     (hist, bins) = np.histogram(spikes, time)
@@ -90,6 +103,8 @@ def getsta(time, stimulus, spikes, filter_length):
 
     """
 
+    dimension_warning(stimulus)
+
     # get the iterator
     ste = getste(time, stimulus, spikes, filter_length)
 
@@ -129,6 +144,8 @@ def getstc(time, stimulus, spikes, filter_length):
         The spike-triggered covariance (STC) matrix
 
     """
+
+    dimension_warning(stimulus)
 
     # initialize
     ndims = np.prod(stimulus.shape[1:]) * filter_length

--- a/pyret/filtertools.py
+++ b/pyret/filtertools.py
@@ -579,7 +579,7 @@ def prinangles(u, v):
     return ang, mag
 
 
-def rolling_window(array, window):
+def rolling_window(array, window, time_axis=-1):
     """
     Make an ndarray with a rolling window of the last dimension
 
@@ -609,10 +609,23 @@ def rolling_window(array, window):
            [ 6.,  7.,  8.]])
 
     """
+
+    if time_axis==0:
+        array = array.T
+    elif time_axis==-1:
+        pass
+    else:
+        raise ValueError('Time axis must be first or last')
+
     assert window >= 1, "`window` must be at least 1."
     assert window < array.shape[-1], "`window` is too long."
 
-    # # with strides
+    # with strides
     shape = array.shape[:-1] + (array.shape[-1] - window, window)
     strides = array.strides + (array.strides[-1],)
-    return np.lib.stride_tricks.as_strided(array, shape=shape, strides=strides)
+    arr = np.lib.stride_tricks.as_strided(array, shape=shape, strides=strides)
+
+    if time_axis==0:
+        return np.rollaxis(arr.T, 1, 0)
+    else:
+        return arr

--- a/pyret/filtertools.py
+++ b/pyret/filtertools.py
@@ -45,6 +45,34 @@ def getste(time, stimulus, spikes, filter_length):
 
 
 def getsta(time, stimulus, spikes, filter_length):
+    """
+    Compute a spike-triggered average
+
+    sta, tax = getsta(time, stimulus, spikes, filter_length)
+
+    Parameters
+    ----------
+    time : ndarray
+        The time array corresponding to the stimulus
+
+    stimulus : ndarray
+        A spatiotemporal or temporal stimulus array
+
+    spikes : iterable
+        A list or ndarray of spike times
+
+    filter_length : int
+        The desired temporal history / length of the STA
+
+    Returns
+    -------
+    sta : ndarray
+        The spatiotemporal spike-triggered average (RF)
+
+    tax : ndarray
+        A time axis corresponding to the STA
+
+    """
 
     # all zeros
     sta_init = np.zeros(stimulus.shape[:-1] + (filter_length,))

--- a/pyret/filtertools.py
+++ b/pyret/filtertools.py
@@ -1,5 +1,6 @@
 """
-Tools ansd utilities for computing spike-triggered averages (filters), finding spatial and temporal components of
+Tools ansd utilities for computing spike-triggered averages (filters),
+finding spatial and temporal components of
 spatiotemporal filters, and basic filter signal processing.
 
 """
@@ -14,12 +15,6 @@ from skimage.restoration import denoise_tv_bregman
 from skimage.filters import gaussian_filter
 from scipy.optimize import curve_fit
 from functools import reduce
-
-# python2 needs imap from itertools, this is just the map function in python3
-try:
-    import itertools.imap as map
-except ImportError:
-    pass
 
 __all__ = ['getste', 'getsta', 'getstc', 'lowranksta', 'decompose',
            'get_ellipse_params', 'fit_ellipse', 'filterpeak', 'smoothfilter',
@@ -37,8 +32,8 @@ def getste(time, stimulus, spikes, filter_length):
 
     # Get indices of non-zero firing, truncating spikes earlier
     # than `filterlength` frames
-    slices = (stimulus[..., (idx - filter_length):idx]
-                      for idx in np.where(hist > 0)[0] if idx > filter_length)
+    slices = (stimulus[(idx - filter_length):idx, ...]
+              for idx in np.where(hist > 0)[0] if idx > filter_length)
 
     # return the iterator
     return slices
@@ -74,14 +69,11 @@ def getsta(time, stimulus, spikes, filter_length):
 
     """
 
-    # all zeros
-    sta_init = np.zeros(stimulus.shape[:-1] + (filter_length,))
-
     # get the iterator
     ste = getste(time, stimulus, spikes, filter_length)
 
     # reduce
-    sta = reduce(lambda sta, x: np.add(sta, x), ste, sta_init) / len(spikes)
+    sta = reduce(lambda sta, x: np.add(sta, x), ste) / float(len(spikes))
 
     # time axis
     tax = time[:filter_length] - time[0]
@@ -92,21 +84,19 @@ def getsta(time, stimulus, spikes, filter_length):
 def getstc(time, stimulus, spikes, filter_length):
 
     # initialize
-    ndims = np.prod(stimulus.shape[:-1]) * filter_length
+    ndims = np.prod(stimulus.shape[1:]) * filter_length
     stc_init = np.zeros((ndims, ndims))
 
     # get the blas function for computing the outer product
     assert stimulus.dtype == 'float64', 'Stimulus must be double precision'
     outer = get_blas_funcs('syr', dtype='d')
 
-    # add an outer product to the covariance matrix
-    outerprod = lambda C, x: outer(1, x.ravel(), a=C)
-
     # get the iterator
     ste = getste(time, stimulus, spikes, filter_length)
 
     # reduce, note that this only contains the upper triangular portion
-    stc_ut = reduce(outerprod, ste, stc_init) / len(spikes)
+    stc_ut = reduce(lambda C, x: outer(1, x.ravel(), a=C),
+                    ste, stc_init) / float(len(spikes))
 
     # make the full STC matrix (copy the upper triangular portion to the lower
     # triangle)
@@ -150,12 +140,13 @@ def lowranksta(f_orig, k=10):
 
     # Compute the SVD of the full filter
     try:
-        u, s, v = np.linalg.svd(f.reshape(-1, f.shape[-1]) - np.mean(f), full_matrices=False)
+        u, s, v = np.linalg.svd(f.reshape(-1, f.shape[-1]) - np.mean(f),
+                                full_matrices=False)
     except LinAlgError:
-        print('The SVD did not converge for the given spatiotemporal filter')
-        print('The data is likely too noisy to compute a rank-{0} approximation'.format(k))
-        print('Try reducing the requested rank.')
-        return None, None, None, None
+        err = '''The SVD did not converge for the given spatiotemporal filter
+              The data is likely too noisy to compute a rank-{0} approximation,
+              try reducing the requested rank.'''.format(k)
+        raise LinAlgError(err)
 
     # Keep the top k components
     k = np.min([k, s.size])
@@ -239,7 +230,8 @@ def _gaussian_function_2d(x, x0, y0, a, b, c):
 
 def _popt_to_ellipse(x0, y0, a, b, c):
     """
-    Converts the parameters for the 2D gaussian function (see `fgauss`) into ellipse parameters
+    Converts the parameters for the 2D gaussian function (see `fgauss`) into
+    ellipse parameters
     """
 
     # convert precision matrix parameters to ellipse parameters
@@ -256,7 +248,8 @@ def _popt_to_ellipse(x0, y0, a, b, c):
 
 def _smooth_spatial_profile(f, spatial_smoothing, tvd_penalty):
     """
-    Smooths a 2D spatial RF profile using a gaussian filter and total variation denoising
+    Smooths a 2D spatial RF profile using a gaussian filter and total variation
+    denoising
 
     Parameters
     ----------
@@ -267,7 +260,7 @@ def _smooth_spatial_profile(f, spatial_smoothing, tvd_penalty):
         width of the gaussian filter
 
     tvd_penalty : float
-        strength of the total variation penalty (note: large values correspond to weaker penalty)
+        TV penalty strength (note: larger values indicate a weaker penalty)
 
     Notes
     -----
@@ -279,7 +272,8 @@ def _smooth_spatial_profile(f, spatial_smoothing, tvd_penalty):
     if sgn*skew(f.ravel()) < 0.1:
         raise ValueError("Error! RF profile is too noisy!")
 
-    H = denoise_tv_bregman(gaussian_filter(sgn * f, spatial_smoothing), tvd_penalty)
+    H = denoise_tv_bregman(gaussian_filter(sgn * f, spatial_smoothing),
+                           tvd_penalty)
     return H / H.max()
 
 
@@ -343,7 +337,8 @@ def get_ellipse_params(tx, ty, sta_frame, spatial_smoothing=1.5, tvd_penalty=100
 
     # optimize
     xdata = np.vstack((xm.ravel(), ym.ravel()))
-    popt, pcov = curve_fit(_gaussian_function_2d, xdata, ydata.ravel(), p0=pinit)
+    popt, pcov = curve_fit(_gaussian_function_2d, xdata, ydata.ravel(),
+                           p0=pinit)
 
     # return ellipse parameters
     return _popt_to_ellipse(*popt)
@@ -375,7 +370,7 @@ def fit_ellipse(tx, ty, sta_frame, spatial_smoothing=1.5, tvd_penalty=100, scale
 
     # Generate ellipse
     ell = Ellipse(xy=center, width=scale * widths[0],
-                   height=scale * widths[1], angle=theta, **kwargs)
+                  height=scale * widths[1], angle=theta, **kwargs)
     return ell
 
 
@@ -440,7 +435,8 @@ def smoothfilter(f, spacesig=0.5, timesig=1):
         The smoothed filter, with the same shape as the input
 
     """
-    return ndimage.filters.gaussian_filter(f, (spacesig, spacesig, timesig), order=0)
+    return ndimage.filters.gaussian_filter(f, (spacesig, spacesig, timesig),
+                                           order=0)
 
 
 def cutout(arr, idx, width=5):
@@ -507,9 +503,9 @@ def prinangles(u, v):
     """
 
     # Orthogonalize each subspace
-    (qu, _), (qv, _) = np.linalg.qr(u), np.linalg.qr(v)
+    qu, qv = np.linalg.qr(u)[0], np.linalg.qr(v)[0]
 
-    # Compute singular values of the inner product between the orthogonalized spaces
+    # singular values of the inner product between the orthogonalized spaces
     mag = np.linalg.svd(qu.T.dot(qv), compute_uv=False, full_matrices=False)
 
     # Compute the angles between each dimension

--- a/pyret/visualizations.py
+++ b/pyret/visualizations.py
@@ -197,7 +197,7 @@ def rasterandpsth(spikes, trial_length=None, binsize=0.01, fig=None):
     return fig
 
 
-def playsta(sta, repeat=True, frametime=100, cmap='gray', clim=None):
+def playsta(sta, repeat=True, frametime=100, cmap='seismic', clim=None):
     """
     Plays a spatiotemporal spike-triggered average as a movie
 
@@ -225,11 +225,11 @@ def playsta(sta, repeat=True, frametime=100, cmap='gray', clim=None):
     """
 
     # Initial frame
-    initial_frame = sta[:, :, 0]
+    initial_frame = sta[0]
 
     # Set up the figure
     fig = plt.figure()
-    ax = plt.axes(xlim=(0, sta.shape[0]), ylim=(0, sta.shape[1]))
+    ax = plt.axes(xlim=(0, sta.shape[1]), ylim=(0, sta.shape[2]))
     img = plt.imshow(initial_frame)
 
     # Set up the colors
@@ -237,14 +237,18 @@ def playsta(sta, repeat=True, frametime=100, cmap='gray', clim=None):
     img.set_interpolation('nearest')
     if clim is not None:
         img.set_clim(clim)
+    else:
+        maxval = np.max(np.abs(sta))
+        img.set_clim([-maxval, maxval])
 
     # Animation function (called sequentially)
     def animate(i):
         ax.set_title('Frame {0:#d}'.format(i + 1))
-        img.set_data(sta[:, :, i])
+        img.set_data(sta[i])
 
     # Call the animator
-    anim = animation.FuncAnimation(fig, animate, np.arange(sta.shape[-1]), interval=frametime, repeat=repeat)
+    anim = animation.FuncAnimation(fig, animate, np.arange(sta.shape[0]),
+                                   interval=frametime, repeat=repeat)
     plt.show()
     plt.draw()
 

--- a/pyret/visualizations.py
+++ b/pyret/visualizations.py
@@ -9,7 +9,7 @@ import seaborn as sns
 from . import filtertools as ft
 from matplotlib import animation as animation
 
-__all__ = ['raster', 'psth', 'rasterandpsth', 'playsta', 'spatial', 'temporal',
+__all__ = ['raster', 'psth', 'rasterandpsth', 'spatial', 'temporal',
            'plotsta', 'playsta', 'ellipse', 'plotcells', 'playrates']
 
 
@@ -229,8 +229,11 @@ def playsta(sta, repeat=True, frametime=100, cmap='seismic', clim=None):
 
     # Set up the figure
     fig = plt.figure()
+    plt.axis('equal')
     ax = plt.axes(xlim=(0, sta.shape[1]), ylim=(0, sta.shape[2]))
     img = plt.imshow(initial_frame)
+    ax.set_xticks([])
+    ax.set_yticks([])
 
     # Set up the colors
     img.set_cmap(cmap)


### PR DESCRIPTION
Flips the expected stimulus dimensions in `filtertools`

Now, stimuli are expected to be of the form (time, space, space) or (time, space) or (time,). Having the time axis come first means that scanning over that dimension is quicker (due to the way contiguous data is stored on memory). A quick test using 100x100 dim. stimuli and 40 time points indicates that this switch makes computing an STA roughly 20% faster. :dash: 

Note: to see these improvements, you need to update how you are storing the stimulus arrays on disk.