### PR TITLE
fixing bug in nonlinearities.Sigmoid

### DIFF
--- a/pyret/nonlinearities.py
+++ b/pyret/nonlinearities.py
@@ -77,7 +77,7 @@ class Sigmoid(BaseEstimator, RegressorMixin, NonlinearityMixin):
         return self
 
     @staticmethod
-    def _sigmoid(x, threshold, slope, peak, baseline):
+    def _sigmoid(x, baseline, peak, slope, threshold):
         return baseline + peak / (1 + np.exp(-slope * (x - threshold)))
 
     def predict(self, x):


### PR DESCRIPTION
There was a bug in nonlinearities.Sigmoid where the parameters returned are mislabeled. For instance, the reported threshold was actually the peak of the sigmoid, the slope of the sigmoid was actually the threshold, and so on. The origin of the bug is a different ordering in the parameters of the internal _sigmoid function and the external-facing Sigmoid(). This PR fixes the different ordering in the internal _sigmoid function.