### PR TITLE
RBF nonlinearity

### DIFF
--- a/docs/releases/v0.6.rst
+++ b/docs/releases/v0.6.rst
@@ -1,0 +1,15 @@
+=============
+v0.6 (Active)
+=============
+
+New features
+------------
+- Adds the ability to extend temporal filters to be acausal (past the time of the spike)
+- Adds an ``RBF`` class for estimating a nonlinearity using tiled radial basis functions.
+
+API changes
+-----------
+
+Bug fixes
+----------
+- Fixes a bug in the ``Sigmoid`` nonlinearity due do shuffled dictionary keys

--- a/pyret/metadata.py
+++ b/pyret/metadata.py
@@ -1,5 +1,5 @@
 # Version info
-__version__ = '0.5.5'
+__version__ = '0.5.6'
 __license__ = 'MIT'
 
 # Project description(s)

--- a/pyret/nonlinearities.py
+++ b/pyret/nonlinearities.py
@@ -173,7 +173,7 @@ class RBF(BaseEstimator, RegressorMixin, NonlinearityMixin):
         widths = np.linspace(-dx, dx, self.n_bases) ** 2 + dx
         self.params = list(zip(centers, widths))
 
-        self.weights, self.resid, *_ = np.linalg.lstsq(self._apply(x), y)
+        self.weights, self.resid = np.linalg.lstsq(self._apply(x), y)[:2]
         return self
 
     def predict(self, x):

--- a/pyret/nonlinearities.py
+++ b/pyret/nonlinearities.py
@@ -141,6 +141,48 @@ class Binterp(BaseEstimator, RegressorMixin, NonlinearityMixin):
         raise NotFittedError('No estimated parameters, call fit() first')
 
 
+class RBF(BaseEstimator, RegressorMixin, NonlinearityMixin):
+    def __init__(self, n_bases):
+        """Smooth nonlinearity parameterized by radial basis functions (gaussians)
+
+        Given samples (x, y) from the nonlinearity, estimates a smooth function using
+        an expansion into a feature basis formed by shifting basis functions (gaussians)
+        along the input scale.
+
+        Parameters
+        ----------
+        n_bases : int
+            How many basis functions to tile along the input axis
+        """
+        self.n_bases = n_bases
+
+    @staticmethod
+    def _gaussian(x, mu, sigma):
+        return np.exp(-(x-mu)**2/sigma**2) / (2 * np.pi * sigma)
+
+    def _apply(self, x):
+        return np.stack([self._gaussian(x, *args) for args in self.params]).T
+
+    def fit(self, x, y):
+
+        # generate tents
+        mu, sigma = np.mean(x), np.std(x)
+        xmin, xmax = mu - 5 * sigma, mu + 5 * sigma
+        dx = (xmax - xmin) / self.n_bases
+        centers = np.linspace(xmin, xmax, self.n_bases)
+        widths = np.linspace(-dx, dx, self.n_bases) ** 2 + dx
+        self.params = list(zip(centers, widths))
+
+        self.weights, self.resid, *_ = np.linalg.lstsq(self._apply(x), y)
+        return self
+
+    def predict(self, x):
+        try:
+            return self._apply(x) @ self.weights
+        except AttributeError:
+            raise NotFittedError('No estimated parameters, call fit() first')
+
+
 class GaussianProcess(GaussianProcessRegressor, NonlinearityMixin):
     def __init__(self, **kwargs):
         self._fitted = False

--- a/pyret/nonlinearities.py
+++ b/pyret/nonlinearities.py
@@ -178,7 +178,7 @@ class RBF(BaseEstimator, RegressorMixin, NonlinearityMixin):
 
     def predict(self, x):
         try:
-            return self._apply(x) @ self.weights
+            return self._apply(x).dot(self.weights)
         except AttributeError:
             raise NotFittedError('No estimated parameters, call fit() first')
 

--- a/tests/test_nonlinearities.py
+++ b/tests/test_nonlinearities.py
@@ -11,9 +11,11 @@ import sklearn
 nonlinearities = [
     (nln.Sigmoid, (), 1234, 0.1, 0.99),
     (nln.Binterp, (50,), 1234, 0.1, 0.99),
+    (nln.RBF, (11,), 1234, 0.1, 0.99),
     (nln.GaussianProcess, (), 1234, 0.1, 0.99),
     (nln.Sigmoid, (), 5678, 0.5, 0.99),
     (nln.Binterp, (25,), 5678, 0.5, 0.99),
+    (nln.RBF, (11,), 1234, 0.5, 0.99),
     (nln.GaussianProcess, (), 5678, 0.5, 0.97),
 ]
 

--- a/tests/test_nonlinearities.py
+++ b/tests/test_nonlinearities.py
@@ -25,14 +25,14 @@ def test_inheritance(nln_cls):
     assert issubclass(nln_cls, nln.NonlinearityMixin)
 
 
-@pytest.mark.parametrize("nln_cls,args,seed,noise_stdev,thresh", nonlinearities)
-def test_exception(nln_cls, args, seed, noise_stdev, thresh):
+@pytest.mark.parametrize("nln_cls,args,seed,noise_stdev,r2_thresh", nonlinearities)
+def test_exception(nln_cls, args, seed, noise_stdev, r2_thresh):
     with pytest.raises(sklearn.exceptions.NotFittedError):
         nln_cls(*args).predict(np.random.randn(100,))
 
 
-@pytest.mark.parametrize("nln_cls,args,seed,noise_stdev,thresh", nonlinearities)
-def test_fitting(nln_cls, args, seed, noise_stdev, thresh):
+@pytest.mark.parametrize("nln_cls,args,seed,noise_stdev,r2_thresh", nonlinearities)
+def test_fitting(nln_cls, args, seed, noise_stdev, r2_thresh):
     """Test the fit method of each nonlinearity"""
     np.random.seed(seed)
 
@@ -51,4 +51,4 @@ def test_fitting(nln_cls, args, seed, noise_stdev, thresh):
     model = nln_cls(*args).fit(x, y_obs)
 
     # compute coefficient of determination (r2)
-    assert model.score(x, y) >= thresh
+    assert model.score(x, y) >= r2_thresh


### PR DESCRIPTION
Adds the ability to fit RBF (radial basis function) nonlinearities. Each nonlinearity is parameterized by a number (`n_bases`) of gaussian basis functions, tiled to cover the input space.

Example of fitting RBF nonlinearities to data drawn from a sigmoidal nonlinearity with different values for `n_bases`:
![image](https://cloud.githubusercontent.com/assets/904854/26660176/ff2aa27a-462a-11e7-8adb-03dcc156ea96.png)