### PR TITLE
Bug fix in linear response method.

### DIFF
--- a/docs/releases/v0.6.rst
+++ b/docs/releases/v0.6.rst
@@ -9,7 +9,14 @@ New features
 
 API changes
 -----------
+- Removes outdated ``stimulustools.rolling_window`` method.
+- In fixing a bug in ``linear_response``, then method now returns an array of the
+  same shape as the stimulus input, rather than one shorter by the length of the
+  filter whose response is computed.
 
 Bug fixes
 ----------
 - Fixes a bug in the ``Sigmoid`` nonlinearity due do shuffled dictionary keys
+- Fixes bug in ``linear_response``, which was supposed to take a filter, but actually
+  took a reverse-correlation.
+- Fixes incorrect documentation for ``stimulustools.slicestim``.

--- a/pyret/filtertools.py
+++ b/pyret/filtertools.py
@@ -688,9 +688,12 @@ def linear_response(filt, stim, nsamples_after=0):
         raise ValueError("The filter and stimulus must have the same "
                          "number of dimensions and match in size along "
                          "spatial dimensions")
+    if (nsamples_after >= filt.shape[0]):
+        raise ValueError("Cannot compute the response of a "
+                "filter with no causal points.")
     padded = np.concatenate((
-            np.zeros((filt.shape[0] - 1,) + stim.shape[1:]), stim,
-            np.zeros((nsamples_after,) + stim.shape[1:])), axis=0)
+            np.zeros((filt.shape[0] - nsamples_after - 1,) + stim.shape[1:]),
+            stim, np.zeros((nsamples_after,) + stim.shape[1:])), axis=0)
     slices = np.fliplr(slicestim(padded, 
             filt.shape[0] - nsamples_after, nsamples_after))
     return np.einsum('tx,x->t', flat2d(slices), filt.ravel())

--- a/pyret/filtertools.py
+++ b/pyret/filtertools.py
@@ -61,7 +61,7 @@ def ste(time, stimulus, spikes, nsamples_before, nsamples_after=0):
 
     # Get indices of non-zero firing, truncating spikes before nsamples_before
     # or after nsamples_after
-    slices = (stimulus[(idx - nb):(idx + na), ...].astype('float64')
+    slices = ((hist[idx] * stimulus[(idx - nb):(idx + na)].astype('float64'))
               for idx in np.where(hist > 0)[0]
               if (idx > nb and (idx + na) < len(stimulus)))
 
@@ -100,7 +100,7 @@ def sta(time, stimulus, spikes, nsamples_before, nsamples_after=0):
 
     tax : ndarray
         A time axis corresponding to the STA, giving the time relative
-        to the spike.
+        to the spike for each time point of the STA.
 
     Notes
     -----
@@ -122,6 +122,10 @@ def sta(time, stimulus, spikes, nsamples_before, nsamples_after=0):
     the STA is unbiased and proportional to the time-reverse of the
     linear filter.
 
+    Note that the ``tax`` time values returned by this method are
+    formally given by ``t_i - \\tau``, i.e., they are the actual
+    time relative to the spike of each corresponding point in the STA.
+
     References
     ----------
     [1] Dayan, P. and L.F. Abbott. Theoretical Neuroscience: Computational
@@ -130,7 +134,7 @@ def sta(time, stimulus, spikes, nsamples_before, nsamples_after=0):
     """
 
     # get the iterator
-    ste_it = ste(time, stimulus, spikes, nsamples_before, nsamples_after=nsamples_after)
+    ste_it = ste(time, stimulus, spikes, nsamples_before, nsamples_after)
 
     # time axis
     filter_length = nsamples_before + nsamples_after
@@ -181,7 +185,7 @@ def stc(time, stimulus, spikes, nsamples_before, nsamples_after=0):
     outer = scipy.linalg.blas.get_blas_funcs('syr', dtype='d')
 
     # get the iterator
-    ste_it = ste(time, stimulus, spikes, nsamples_before, nsamples_after=nsamples_after)
+    ste_it = ste(time, stimulus, spikes, nsamples_before, nsamples_after)
 
     filter_length = nsamples_before + nsamples_after
 
@@ -257,7 +261,7 @@ def lowranksta(sta_orig, k=10):
 
     # Compute the SVD of the full STA
     assert f.ndim >= 2, "STA must be at least 2-D"
-    u, s, v = np.linalg.svd(f.reshape(f.shape[0], -1), full_matrices=False)
+    u, s, v = np.linalg.svd(flat2d(f), full_matrices=False)
 
     # Keep the top k components
     k = np.min([k, s.size])
@@ -271,7 +275,8 @@ def lowranksta(sta_orig, k=10):
     # Ensure that the computed STA components have the correct sign.
     # The full STA should have positive projection onto first temporal
     # component of the low-rank STA.
-    sign = np.sign(np.einsum('i,ijk->jk', u[:, 0], f).sum())
+    sign = np.sign(np.tensordot(u[:, 0], f, axes=1).sum())
+    print(sign)
     u *= sign
     v *= sign
 
@@ -376,12 +381,13 @@ def cutout(arr, idx=None, width=5):
     Parameters
     ----------
     arr : array_like
-        Stimulus, STA, or filter array from which the chunk is cut out. The array
-        should be shaped as ``(time, spatial, spatial)``.
+        Stimulus, STA, or filter array from which the chunk is cut out. The
+        array should be shaped as ``(time, spatial, spatial)``.
 
     idx : array_like, optional
         2D array specifying the row and column indices of the center of the
-        section to be cut out (if None, the indices are taken from ``filterpeak``).
+        section to be cut out (if None, the indices are taken from
+        ``filterpeak``).
 
     width : int, optional
         The size of the chunk to cut out from the start indices. Defaults
@@ -454,12 +460,14 @@ def resample(arr, scale_factor):
     assert scale_factor > 0, "Scale factor must be non-negative"
 
     if arr.ndim == 1:
-        return scipy.signal.resample(arr, int(np.ceil(scale_factor * arr.size)))
+        return scipy.signal.resample(arr,
+                int(np.ceil(scale_factor * arr.size)))
 
     elif arr.ndim == 2:
         assert arr.shape[0] == arr.shape[1], "Array must be square"
         n = int(np.ceil(scale_factor * arr.shape[0]))
-        return scipy.signal.resample(scipy.signal.resample(arr, n, axis=0), n, axis=1)
+        return scipy.signal.resample(
+                scipy.signal.resample(arr, n, axis=0), n, axis=1)
 
     else:
         raise ValueError('Input array must be either 1-D or 2-D')
@@ -610,8 +618,8 @@ def rfsize(spatial_filter, dx, dy=None, sigma=2.):
         value as dx. (Default: None)
 
     sigma : float, optional
-        Determines the size of the ellipse contour, in units of standard deviation
-        of the fitted gaussian. E.g., 2.0 means a 2 SD ellipse.
+        Determines the size of the ellipse contour, in units of standard
+        deviation of the fitted gaussian. E.g., 2.0 means a 2 SD ellipse.
 
     Returns
     -------
@@ -639,14 +647,14 @@ def linear_response(filt, stim, nsamples_after=0):
     ----------
     filt : array_like
         The linear filter whose response is to be computed. The array should
-        have shape ``(t, ...)``, where ``t`` is the number of time points in the
-        filter and the ellipsis indicates any remaining spatial dimenions.
+        have shape ``(t, ...)``, where ``t`` is the number of time points in
+        the filter and the ellipsis indicates any remaining spatial dimenions.
         The number of dimensions and the sizes of the spatial dimensions
         must match that of ``stim``.
 
     stim : array_like
         The stimulus to which the predicted response is computed. The array
-        should have shape (T,...), where ``T`` is the number of time points
+        should have shape ``(T,...)``, where ``T`` is the number of time points
         in the stimulus and the ellipsis indicates any remaining spatial
         dimensions. The number of dimensions and the sizes of the spatial
         dimenions must match that of ``filt``.
@@ -657,10 +665,7 @@ def linear_response(filt, stim, nsamples_after=0):
     Returns
     -------
     pred : array_like
-        The predicted linear response. The shape is ``(T - t + 1,)`` where
-        ``T`` is the number of time points in the stimulus, and ``t`` is
-        the number of time points in the filter. This is the valid portion
-        of the convolution between the stimulus and filter.
+        The predicted linear response, of shape ``(t,)``.
 
     Raises
     ------
@@ -669,6 +674,11 @@ def linear_response(filt, stim, nsamples_after=0):
 
     Notes
     -----
+    Note that the first parameter is a *linear filter*. The values returned by
+    ``filtertools.sta`` and ``filtertools.revcorr`` are proportional to the
+    time-reverse of the linear filter, so to use those values in this function,
+    they must be flipped along the first dimension.
+
     Both ``filtertools.sta`` and ``filtertools.revcorr`` can estimate "acausal"
     components, such as points in the stimulus occuring *after* a spike. The
     value passed as parameter ``nsamples_after`` must match that value used
@@ -676,10 +686,14 @@ def linear_response(filt, stim, nsamples_after=0):
 
     """
     if (filt.ndim != stim.ndim) or (filt.shape[1:] != stim.shape[1:]):
-        raise ValueError("The filter and stimulus must have the same " +
-                         "number of dimensions and match in size along spatial dimensions")
-
-    slices = slicestim(stim, filt.shape[0] - nsamples_after, nsamples_after)
+        raise ValueError("The filter and stimulus must have the same "
+                         "number of dimensions and match in size along "
+                         "spatial dimensions")
+    padded = np.concatenate((
+            np.zeros((filt.shape[0] - 1, *stim.shape[1:])), stim,
+            np.zeros((nsamples_after, *stim.shape[1:]))), axis=0)
+    slices = np.fliplr(slicestim(padded, 
+            filt.shape[0] - nsamples_after, nsamples_after))
     return np.einsum('tx,x->t', flat2d(slices), filt.ravel())
 
 
@@ -704,25 +718,27 @@ def revcorr(stimulus, response, nsamples_before, nsamples_after=0):
         completely overlap.
 
     nsamples_before : int
-        The maximum negative lag for the correlation between stimulus and response,
-        in samples.
+        The maximum negative lag for the correlation between stimulus and
+        response, in samples.
 
     nsamples_after : int, optional
-        The maximum positive lag for the correlation between stimulus and response,
-        in samples. Defaults to 0.
+        The maximum positive lag for the correlation between stimulus and
+        response, in samples. Defaults to 0.
 
     Returns
     -------
     rc : array_like
         An array of shape ``(nsamples_before + nsamples_after, ...)``
-        containing the best-fitting linear filter which predicts the response from
-        the stimulus. The ellipses indicates spatial dimensions of the filter.
+        containing the best-fitting linear filter which predicts the response
+        from the stimulus. The ellipses indicates spatial dimensions of the
+        filter.
 
     lags : array_like
         An array of shape ``(nsamples_before + nsamples_after,)``, which gives
-        the lags, in samples, between ``stimulus`` and ``response`` for the correlation
-        returned in ``rc``. This can be converted to an axis of time (like that
-        returned from ``filtertools.sta``) by multiplying by the sampling period.
+        the lags, in samples, between ``stimulus`` and ``response`` for the
+        correlation returned in ``rc``. This can be converted to an axis of time
+        (like that returned from ``filtertools.sta``) by multiplying by the 
+        sampling period.
 
     Raises
     ------
@@ -754,6 +770,9 @@ def revcorr(stimulus, response, nsamples_before, nsamples_after=0):
     array increase with increasing array index. This means that time is moving
     forward with increasing array index.
 
+    Also note that this method assumes an uncorrelated stimulus. If the
+    stimulus is correlated, those will bias the estimated reverse correlation.
+
     """
     history = nsamples_before + nsamples_after
     if response.ndim > 1:
@@ -761,11 +780,10 @@ def revcorr(stimulus, response, nsamples_before, nsamples_after=0):
     if response.size != stimulus.shape[0]:
         raise ValueError('`stimulus` and `response` must match in ' +
                 'size along the first axis')
-
     slices = slicestim(stimulus, nsamples_before, nsamples_after)
     recovered = np.einsum('tx,t->x', flat2d(slices),
             response[history - 1:]).reshape(slices.shape[1:])
-    lags = np.arange(-nsamples_before, nsamples_after)
+    lags = np.arange(-nsamples_before + 1, nsamples_after + 1)
     return recovered, lags
 
 

--- a/pyret/filtertools.py
+++ b/pyret/filtertools.py
@@ -689,8 +689,8 @@ def linear_response(filt, stim, nsamples_after=0):
                          "number of dimensions and match in size along "
                          "spatial dimensions")
     padded = np.concatenate((
-            np.zeros((filt.shape[0] - 1, *stim.shape[1:])), stim,
-            np.zeros((nsamples_after, *stim.shape[1:]))), axis=0)
+            np.zeros((filt.shape[0] - 1,) + stim.shape[1:]), stim,
+            np.zeros((nsamples_after,) + stim.shape[1:])), axis=0)
     slices = np.fliplr(slicestim(padded, 
             filt.shape[0] - nsamples_after, nsamples_after))
     return np.einsum('tx,x->t', flat2d(slices), filt.ravel())

--- a/pyret/filtertools.py
+++ b/pyret/filtertools.py
@@ -276,7 +276,6 @@ def lowranksta(sta_orig, k=10):
     # The full STA should have positive projection onto first temporal
     # component of the low-rank STA.
     sign = np.sign(np.tensordot(u[:, 0], f, axes=1).sum())
-    print(sign)
     u *= sign
     v *= sign
 

--- a/pyret/metadata.py
+++ b/pyret/metadata.py
@@ -1,5 +1,5 @@
 # Version info
-__version__ = '0.5.7'
+__version__ = '0.6.0'
 __license__ = 'MIT'
 
 # Project description(s)

--- a/pyret/stimulustools.py
+++ b/pyret/stimulustools.py
@@ -118,22 +118,32 @@ def slicestim(stimulus, nsamples_before, nsamples_after=0):
     slices : array_like
         A view onto the original stimulus array, giving the overlapping slices
         of the stimulus. The full shape of the returned array is:
-        ``(history, stimulus.shape[0] - history, ...)``, where
+        ``(stimulus.shape[0] - history + 1, history ...)``, where
         ``history == nsamples_before + nafter``. As above, the ellipses
         indicate any spatial dimensions to the stimulus.
 
     Examples
     --------
-    >>> x=np.arange(10).reshape((5, 2))
+    >>> x = np.arange(15).reshape((5, 3))
     >>> slicestim(x, 3)
-    array([[[0, 1, 2], [1, 2, 3], [2, 3, 4]],
-           [[5, 6, 7], [6, 7, 8], [7, 8, 9]]])
+    array([[[ 0,  1,  2],
+            [ 3,  4,  5]],
 
+           [[ 3,  4,  5],
+            [ 6,  7,  8]],
+
+           [[ 6,  7,  8],
+            [ 9, 10, 11]],
+
+           [[ 9, 10, 11],
+            [12, 13, 14]]])
     Calculate rolling mean of last dimension:
 
     >>> np.mean(slicestim(x, 3), -1)
-    array([[ 1.,  2.,  3.],
-           [ 6.,  7.,  8.]])
+     array([[ 1.,  4.],
+           [ 4.,  7.],
+           [ 7., 10.],
+           [10., 13.]])
 
     Notes
     -----
@@ -147,8 +157,8 @@ def slicestim(stimulus, nsamples_before, nsamples_after=0):
     allow computing acausal components of an STA (points *after* a spike occurs),
     this method must also allow that in order to keep the temporal alignment.
 
-    Practically this means that one must always pass the same value to
-    ``stimulustools.slicestim`` as is passed to ``filtertools.sta`` or
+    Practically this means that one must always pass the same value for the
+    ``nsamples_after`` argument as is passed to ``filtertools.sta`` or
     ``filtertools.revcorr``.
 
     """
@@ -191,45 +201,3 @@ def cov(stimulus, history, nsamples=None, verbose=False):
     """
     stim = slicestim(stimulus, history)
     return np.cov(flat2d(stim).T)
-
-
-def rolling_window(array, window, time_axis=0):
-    """
-    Make an ndarray with a rolling window of the last dimension
-
-    Parameters
-    ----------
-    array : array_like
-        Array to add rolling window to
-
-    window : int
-        Size of rolling window
-
-    time_axis : int, optional
-        The axis of the temporal dimension, either 0 or -1 (Default: 0)
-
-    Returns
-    -------
-    Array that is a view of the original array with a added dimension
-    of size w.
-
-    Examples
-    --------
-    >>> x=np.arange(10).reshape((2,5))
-    >>> rolling_window(x, 3)
-    array([[[0, 1, 2], [1, 2, 3], [2, 3, 4]],
-           [[5, 6, 7], [6, 7, 8], [7, 8, 9]]])
-
-    Calculate rolling mean of last dimension:
-
-    >>> np.mean(rolling_window(x, 3), -1)
-    array([[ 1.,  2.,  3.],
-           [ 6.,  7.,  8.]])
-
-    """
-    with warnings.catch_warnings():
-        warnings.simplefilter('always')
-        warnings.warn('`rolling_window` is deprecated and will be removed' +
-                ' in future releases. Use `stimulustools.slicestim` instead.',
-                DeprecationWarning)
-    return slicestim(array, window)

--- a/tests/test_filtertools.py
+++ b/tests/test_filtertools.py
@@ -276,11 +276,22 @@ def test_linear_response_acausal():
     the filter to an impulse should return the filter itself, plus
     zeros at any acausal time points.
     """
-    filt = np.array(((1, 0, 0)))
+    nacausal_points = 1
+    filt = np.concatenate((np.zeros((nacausal_points,)), (1, 0, 0)), axis=0)
     stim = np.concatenate(((1,), np.zeros((10,))), axis=0)
-    pred = flt.linear_response(filt, stim, 10)
-    assert np.allclose(pred[:filt.size], filt)
+    pred = flt.linear_response(filt, stim, nacausal_points)
+    assert np.allclose(pred[:filt.size - nacausal_points],
+            filt[nacausal_points:])
     assert np.allclose(pred[filt.size:], np.zeros_like(pred[filt.size:]))
+
+
+def test_linear_response_only_acausal():
+    """Test that calling ``linear_response`` with only acausal
+    points is invalid.
+    """
+    with pytest.raises(ValueError):
+        flt.linear_response(np.zeros((3,)), np.zeros((10,)),
+                nsamples_after=3)
 
 
 def test_linear_response_nd():

--- a/tests/test_filtertools.py
+++ b/tests/test_filtertools.py
@@ -290,9 +290,9 @@ def test_linear_response_nd():
     should return the filter itself, scaled by the number of spatial points.
     """
     for ndim in range(2, 4):
-        filt = np.zeros((3, *((2,) * ndim)))
+        filt = np.zeros((3,) + ((2,) * ndim))
         filt[0] = 1.
-        stim = np.zeros((10, *((2,) * ndim)))
+        stim = np.zeros((10,) + ((2,) * ndim))
         stim[0] = 1.
         pred = flt.linear_response(filt, stim)
         assert np.allclose(pred[0], filt[0].sum())
@@ -367,9 +367,9 @@ def test_revcorr_nd():
     linear filter, scaled by the number of spatial points.
     """
     ndim = 3
-    filt = np.zeros((3, *((2,) * ndim)))
+    filt = np.zeros((3,) + ((2,) * ndim))
     filt[0] = 1.
-    stim = np.zeros((10, *((2,) * ndim)))
+    stim = np.zeros((10,) + ((2,) * ndim))
     stim[5] = 1.
     response = flt.linear_response(filt, stim)
     recovered, lags = flt.revcorr(stim, response, filt.shape[0])

--- a/tests/test_filtertools.py
+++ b/tests/test_filtertools.py
@@ -102,23 +102,71 @@ def test_empty_stc():
     assert np.all(np.isnan(tmp))
 
 
-def test_decompose():
-    """Tests computing a rank-1 approximation to a filter.
-    Note that this tests both filtertools.decompose() and filtertools.lowranksta().
+def test_decompose_2d():
+    """Tests computing a rank-1 approximation to a 2D filter.
+    Note that this tests both ``filtertools.decompose()`` and
+    ``filtertools.lowranksta()``.
     """
     np.random.seed(0)
     filter_length = 50
-    nx, ny = 10, 10
-    temporal, spatial, true_filter = utils.create_spatiotemporal_filter(nx, ny, filter_length)
-
-    noise_std = 0.01
+    nx = 10
+    def gaussian(x, mu, sigma):
+        return np.exp(-((x - mu) / sigma)**2) / np.sqrt(sigma * 2 * np.pi)
+    temporal = gaussian(np.linspace(-3, 3, filter_length), -1, 1.5)
+    spatial = gaussian(np.linspace(-3, 3, nx), 0, 1.0)
+    true_filter = np.outer(temporal, spatial)
+    noise_std = 0.01 * (temporal.max() - temporal.min())
     true_filter += np.random.randn(*true_filter.shape) * noise_std
 
     s, t = flt.decompose(true_filter)
+   
+    # s/t are unit vectors, scale them and the inputs
+    s -= s.min()
+    s /= s.max()
+    t -= t.min()
+    t /= t.max()
+    temporal -= temporal.min()
+    temporal /= temporal.max()
+    spatial -= spatial.min()
+    spatial /= spatial.max()
 
     tol = 0.1
     assert np.allclose(temporal, t, atol=tol)
     assert np.allclose(spatial, s, atol=tol)
+
+
+def test_decompose_3d():
+    """Tests computing a rank-1 approximation to a 3D filter.
+    Note that this tests both ``filtertools.decompose()`` and
+    ``filtertools.lowranksta()``.
+    """
+    np.random.seed(0)
+    filter_length = 50
+    nx, ny = 10, 10
+    def gaussian(x, mu, sigma):
+        return np.exp(-((x - mu) / sigma)**2) / np.sqrt(sigma * 2 * np.pi)
+    temporal = gaussian(np.linspace(-3, 3, filter_length), -1, 1.5)
+    spatial = gaussian(np.linspace(-3, 3, nx * ny), 0, 1.0).reshape(nx, ny)
+    true_filter = np.outer(temporal, spatial.ravel())
+    noise_std = 0.01 * (temporal.max() - temporal.min())
+    true_filter += np.random.randn(*true_filter.shape) * noise_std
+
+    s, t = flt.decompose(true_filter)
+   
+    # s/t are unit vectors, scale them and the inputs
+    s -= s.min()
+    s /= s.max()
+    t -= t.min()
+    t /= t.max()
+    temporal -= temporal.min()
+    temporal /= temporal.max()
+    spatial -= spatial.min()
+    spatial /= spatial.max()
+
+    tol = 0.1
+    assert np.allclose(temporal, t, atol=tol)
+    assert np.allclose(spatial.ravel(), s.ravel(), atol=tol)
+
 
 def test_filterpeak():
     """Test finding the maximal point in a 3D filter"""
@@ -132,6 +180,7 @@ def test_filterpeak():
     assert true_indices[0] == tidx
     assert np.all(true_indices[1:] == sidx)
 
+
 def test_cutout():
     """Test cutting out a small tube through a 3D spatiotemporal filter"""
     np.random.seed(0)
@@ -140,18 +189,24 @@ def test_cutout():
     cutout = flt.cutout(arr, (2, 2), width=1)
     assert np.allclose(cutout, chunk)
 
+
 def test_cutout_peak():
-    """Test that the `filtertools.cutout()` method correctly uses the filter peak."""
+    """Test that the `filtertools.cutout()` method correctly
+    uses the filter peak."""
     chunk = np.zeros((4, 2, 2))
     chunk[2, 1, 1] = 1
-    arr = np.pad(chunk, ((0, 0), (1, 1), (1, 1)), 'constant', constant_values=0)
+    arr = np.pad(chunk, ((0, 0), (1, 1), (1, 1)),
+            'constant', constant_values=0)
     cutout = flt.cutout(arr, width=1)
     assert np.allclose(cutout, chunk)
 
+
 def test_cutout_raises():
-    """Test cutout() raises an exception when the index argument does not have two elements."""
+    """Test cutout() raises an exception when the index argument
+    does not have two elements."""
     with pytest.raises(ValueError):
         flt.cutout(np.zeros((10, 10, 10)), (1,))
+
 
 def test_resample():
     """Test resampling a 1 or 2D array."""
@@ -174,166 +229,149 @@ def test_resample():
     assert np.allclose(orig_power[:int(size / 2), :int(size / 2)],
             up_power[:int(size / 2), :int(size / 2)])
 
+
 def test_normalize_spatial():
     """Test normalizing a noisy filter."""
     np.random.seed(0)
-    filter_length = 100
     nx, ny = 10, 10
-    true_filter = utils.create_spatiotemporal_filter(nx, ny, filter_length)[1]
+    shape = (nx, ny)
+    true_filter = np.random.randn(*shape)
     noise_std = 0.01
-    noisy_filter = true_filter + 1.0 + np.random.randn(*true_filter.shape) * 0.01
+    noisy_filter = true_filter + 1.0 * np.random.randn(*shape) * noise_std
 
     normalized = flt.normalize_spatial(noisy_filter)
-    normalized /= np.linalg.norm(normalized)
 
     atol = 0.1
     assert np.allclose(normalized, true_filter, atol=atol)
 
+
 def test_rfsize():
     np.random.seed(0)
-    filter_length = 100
     nx, ny = 10, 10
-    true_filter = utils.create_spatiotemporal_filter(nx, ny, filter_length)[1]
+    from pyret.filtertools import _gaussian_function
+    x, y = np.meshgrid(np.linspace(-3, 3, nx), np.linspace(-3, 3, ny))
+    points = np.stack((x.ravel(), y.ravel()), axis=0)
+    true_filter = _gaussian_function(points, 0, 0, 1, 0, 1).reshape(nx, ny)
 
     xsize, ysize = flt.rfsize(true_filter, 1., 1.)
-    assert np.allclose(xsize, 3., 0.1) # 1 SD is about 3 units
-    assert np.allclose(ysize, 3., 0.1)
+    assert np.allclose(xsize, 4, 0.1) # 2SDs on either side == RF size
+    assert np.allclose(ysize, 4., 0.1)
 
 
 def test_linear_response_1d():
     """Test method for computing linear response from a
-    filter to a one-dimensional stimulus.
+    filter to a one-dimensional stimulus. The linear response of the
+    filter to an impulse should return the filter itself.
     """
-    np.random.seed(0)
-    filt = np.random.randn(100,)
-    stim = np.random.randn(1000,)
-    pred = flt.linear_response(filt, stim)
-
-    sl = slicestim(stim, filt.shape[0])
-    assert np.allclose(sl.dot(filt), pred)
+    filt = np.array(((1, 0, 0)))
+    stim = np.concatenate(((1,), np.zeros((10,))), axis=0)
+    pred = flt.linear_response(filt, stim) # Impulse response is linear filter
+    assert np.allclose(pred[:filt.size], filt)
+    assert np.allclose(pred[filt.size:], np.zeros_like(pred[filt.size:]))
 
 
 def test_linear_response_acausal():
     """Test computing a linear response from a filter to a 1D stimulus,
-    including acausal portions of the stimulus.
+    including acausal portions of the stimulus. The linear response of
+    the filter to an impulse should return the filter itself, plus
+    zeros at any acausal time points.
     """
-    np.random.seed(0)
-    filt = np.random.randn(100,)
-    stim = np.random.randn(1000,)
+    filt = np.array(((1, 0, 0)))
+    stim = np.concatenate(((1,), np.zeros((10,))), axis=0)
     pred = flt.linear_response(filt, stim, 10)
-
-    sl = slicestim(stim, filt.shape[0] - 10, 10)
-    assert np.allclose(sl.dot(filt), pred)
+    assert np.allclose(pred[:filt.size], filt)
+    assert np.allclose(pred[filt.size:], np.zeros_like(pred[filt.size:]))
 
 
 def test_linear_response_nd():
     """Test method for computing linear response from a
-    filter to a multi-dimensional stimulus.
+    filter to a multi-dimensional stimulus. The linear response of
+    the filter to an impulse (1 at first time point in all spatial dimensions)
+    should return the filter itself, scaled by the number of spatial points.
     """
-    np.random.seed(0)
     for ndim in range(2, 4):
-        filt = np.random.randn(100, *((10,) * ndim))
-        stim = np.random.randn(1000, *((10,) * ndim))
+        filt = np.zeros((3, *((2,) * ndim)))
+        filt[0] = 1.
+        stim = np.zeros((10, *((2,) * ndim)))
+        stim[0] = 1.
         pred = flt.linear_response(filt, stim)
-
-        sl = slicestim(stim, filt.shape[0])
-        tmp = np.zeros(sl.shape[0])
-        for i in range(tmp.size):
-            tmp[i] = np.inner(filt.ravel(), sl[i].ravel())
-
-        assert np.allclose(tmp, pred)
+        assert np.allclose(pred[0], filt[0].sum())
+        assert np.allclose(pred[1:], np.zeros_like(pred[1:]))
 
 
 def test_linear_response_raises():
     """Test raising ValueErrors with incorrect inputs"""
-    np.random.seed(0)
     with pytest.raises(ValueError):
-        flt.linear_response(np.random.randn(10,), np.random.randn(10,2))
+        flt.linear_response(np.zeros((10,)), np.zeros((10,2)))
     with pytest.raises(ValueError):
-        flt.linear_response(np.random.randn(10, 2), np.random.randn(10, 3))
+        flt.linear_response(np.zeros((10, 2)), np.zeros((10, 3)))
 
 
 def test_revcorr_raises():
     """Test raising ValueErrors with incorrect inputs"""
-    np.random.seed(0)
     with pytest.raises(ValueError):
-        flt.revcorr(np.random.randn(10, 1), np.random.randn(11,), 2)[0]
+        flt.revcorr(np.zeros((10, 1)), np.zeros((11,)), 2)[0]
     with pytest.raises(ValueError):
-        flt.revcorr(np.random.randn(10, 3), np.random.randn(10, 2), 2)[0]
+        flt.revcorr(np.zeros((10, 3)), np.zeros((10, 2)), 2)[0]
+
+
+def test_revcorr_1d_ignores_beginning():
+    """Verify revcorr ignores the first filter-length points of the stimulus,
+    to only consider those points which the response and stimulus overlap
+    completely.
+    """
+    filt = np.array(((1, 0, 0)))
+    stim = np.concatenate(((1,), np.zeros((10,))), axis=0)
+    response = np.convolve(filt, stim, 'full')[:stim.size]
+    recovered, lags = flt.revcorr(stim, response, filt.size)
+    assert np.allclose(recovered, 0)
 
 
 def test_revcorr_1d():
-    """Test computation of a 1D linear filter by reverse correlation"""
-    np.random.seed(0)
-
-    # Create fake filter, 100 time points
-    filter_length = 100
-    true_filter = utils.create_temporal_filter(filter_length)
-
-    # Compute linear response
-    stim_length = 10000
-    stimulus = np.random.randn(stim_length,)
-    response = flt.linear_response(true_filter, stimulus)
-
-    # Reverse correlation, pad response with zeros to so that
-    # stim and response match. These will be ignored by
-    # filtertools.revcorr anyway.
-    padded_response = np.concatenate((np.zeros((filter_length - 1,)),
-            response), axis=0)
-    filt = flt.revcorr(stimulus, padded_response, filter_length)[0]
-    filt /= np.linalg.norm(filt)
-    tol = 0.1
-    assert np.allclose(true_filter, filt, atol=tol)
+    """Test computation of 1D reverse correlation.
+    The reverse-correlation should recover the time-reverse of the
+    linear filter, and the lags should be start at negative values
+    and be strictly increasing.
+    """
+    filt = np.array(((1, 0, 0)))
+    stim = np.zeros((10,))
+    stim[5] = 1
+    response = np.convolve(filt, stim, 'full')[:stim.size]
+    recovered, lags = flt.revcorr(stim, response, filt.size)
+    assert np.allclose(recovered, filt[::-1])
+    assert lags[0] == -(filt.size - 1)
+    assert (np.diff(lags) == 1).all()
 
 
 def test_revcorr_acausal():
     """Test computation of a 1D linear filter by reverse correlation,
-    including acausal lag values.
+    including acausal lag values. The reverse-correlation should recover
+    the time-reverse of the linear filter.
     """
-    np.random.seed(0)
-
-    # Create fake filter, 100 time points
-    nbefore, nafter = 90, 10
-    filter_length = nbefore + nafter
-    true_filter = utils.create_temporal_filter(filter_length)
-
-    # Compute linear response
-    stim_length = 10000
-    stimulus = np.random.randn(stim_length,)
-    response = flt.linear_response(true_filter, stimulus)
-
-    # Reverse correlation, pad response with zeros to so that
-    # stim and response match. These will be ignored by
-    # filtertools.revcorr anyway.
-    padded_response = np.concatenate((np.zeros((filter_length - 1,)),
-            response), axis=0)
-    filt = flt.revcorr(stimulus, padded_response, nbefore, nafter)[0]
-    filt /= np.linalg.norm(filt)
-    tol = 0.1
-    assert np.allclose(true_filter, filt, atol=tol)
+    filt = np.array(((1, 0, 0)))
+    stim = np.zeros((10,))
+    stim[5] = 1.0
+    response = np.convolve(filt, stim, 'full')[:stim.size]
+    nsamples_after = 2
+    recovered, lags = flt.revcorr(stim, response, filt.size, nsamples_after)
+    assert np.allclose(recovered[nsamples_after:], filt[::-1])
+    assert np.allclose(recovered[:filt.size], 0)
+    assert lags[0] == -(filt.size - 1)
+    assert lags[-1] == nsamples_after
+    assert (np.diff(lags) == 1).all()
 
 
 def test_revcorr_nd():
-    np.random.seed(0)
-
-    """Test computation of 3D linear filter by reverse correlation"""
-    # Create fake filter
-    filter_length = 100
-    nx, ny = 10, 10
-    true_filter = utils.create_spatiotemporal_filter(nx, ny, filter_length)[-1]
-
-    # Compute linear response
-    stim_length = 10000
-    stimulus = np.random.randn(stim_length, nx, ny)
-    response = flt.linear_response(true_filter, stimulus)
-
-    # Reverse correlation, pad response with zeros to so that
-    # stim and response match. These will be ignored by
-    # filtertools.revcorr anyway.
-    padded_response = np.concatenate((np.zeros((filter_length - 1,)),
-            response), axis=0)
-    filt = flt.revcorr(stimulus, padded_response, filter_length)[0]
-    filt /= np.linalg.norm(filt)
-    tol = 0.1
-    assert np.allclose(true_filter, filt, atol=tol)
-
+    """Test computation of 3D linear filter by reverse correlation.
+    The reverse correlation should return the time-reverse of the
+    linear filter, scaled by the number of spatial points.
+    """
+    ndim = 3
+    filt = np.zeros((3, *((2,) * ndim)))
+    filt[0] = 1.
+    stim = np.zeros((10, *((2,) * ndim)))
+    stim[5] = 1.
+    response = flt.linear_response(filt, stim)
+    recovered, lags = flt.revcorr(stim, response, filt.shape[0])
+    assert np.allclose(recovered[-1], filt[0].sum())
+    assert np.allclose(recovered[:-1], 0)

--- a/tests/test_stimulustools.py
+++ b/tests/test_stimulustools.py
@@ -52,6 +52,14 @@ def test_slicestim_raises():
     with pytest.raises(ValueError):
         stimulustools.slicestim(np.zeros(10,), 1.5)
 
+
+def test_slicestim_shape():
+    shape = (10, 3, 3)
+    history = 2
+    stim = np.zeros(shape)
+    assert (stimulustools.slicestim(stim, history).shape ==
+            (shape[0] - history + 1, history, shape[1], shape[2]))
+
 def test_slicestim_1d():
     """Test slicing a 1D stimulus into overlapping segments."""
     np.random.seed(0)
@@ -96,17 +104,3 @@ def test_cov():
     np.random.seed(0)
     stim = np.random.randn(10, 2)
     assert np.allclose(np.cov(stim.T), stimulustools.cov(stim, 1))
-
-def test_rolling_window_warns():
-    """Verify calling rolling_window results in Deprecation warning, but still returns
-    the correct value.
-    """
-    with pytest.warns(DeprecationWarning):
-        np.random.seed(0)
-        stim_size = 1000
-        stim = np.random.randn(stim_size,)
-        history = 10
-        sliced_stim = stimulustools.rolling_window(stim, history)
-
-        for i in range(stim_size - history):
-            assert np.all(sliced_stim[i] == stim[i:i + history]), 'slicing failed'


### PR DESCRIPTION
This set of commits fixes a few bugs.

1. `filtertools.sta` did not count a set of frames more than once if more than one spike occurred in the corresponding time bin. That is, a frame with 1 spike and a frame with 1000 spikes have the same weight in the STA. Now each set of frames is weighted by the number of spikes in the bin.

2. `filtertools.linear_response` was incorrect. It both ignored the initial (but still valid) portion of the response of the filter, and took a reverse-correlation, and *not* a linear filter as the docs claimed. This was solved by padding the stimulus with zeros before slicing, and then flipping the slices along the time axis.

The commit also simplifies tests for the `filtertools` module, using impulses as the stimuli, which are much easier to reason about and see errors in. It also clarifies the docs for a few things, and updates the quickstart to account for all these changes.