### PR TITLE
Changes filtering method in firing-rate estimation routines.

### DIFF
--- a/pyret/spiketools.py
+++ b/pyret/spiketools.py
@@ -8,6 +8,7 @@ for smoothing a histogram into a firing rate (`estfr`)
 """
 import sys
 import numpy as np
+from scipy import signal
 import matplotlib.pyplot as plt
 from collections import Counter
 
@@ -65,7 +66,7 @@ def estfr(bspk, time, sigma=0.01):
     size = int(np.round(filt.size / 2))
 
     # Filter  binned spike times
-    return np.convolve(filt, bspk, mode='full')[size:size + time.size] / dt
+    return signal.fftconvolve(filt, bspk, mode='full')[size:size + time.size] / dt
 
 
 class SpikingEvent(object):

--- a/pyret/visualizations.py
+++ b/pyret/visualizations.py
@@ -199,7 +199,6 @@ def raster_and_psth(spikes, trial_length=None, binsize=0.01, **kwargs):
 
     # Plot the raster
     rastax = ax.twinx()
-    plt.hold(True)
     for trial in range(ntrials):
         idx = np.bitwise_and(spikes > tbins[trial, 0],
                              spikes <= tbins[trial, -1])

--- a/tests/test_spiketools.py
+++ b/tests/test_spiketools.py
@@ -36,7 +36,7 @@ def test_estfr():
     # test a single spike
     bspk[T // 2] = 1.
     fr = spk.estfr(bspk, time, sigma=0.01)
-    assert (fr.sum() * dt) == bspk.sum()
+    assert np.isclose((fr.sum() * dt), bspk.sum())
 
 
 def test_spiking_events():


### PR DESCRIPTION
Uses `scipy.signal`s FFT-based convolution rather than the direct method as implemented in NumPy. Runtime should change from O(n**2) to O(n log n).